### PR TITLE
バックエンドエラーハンドリング実装

### DIFF
--- a/backend/internal/infrastructure/errors/README.md
+++ b/backend/internal/infrastructure/errors/README.md
@@ -1,0 +1,164 @@
+# Error Handling System
+
+This package provides a comprehensive error handling system for the Knowledge Hub backend application. It includes custom error types, error codes, standardized error responses, validation error handling, and logging functionality.
+
+## Features
+
+- Custom error types for different layers (domain, application, infrastructure)
+- Error codes with HTTP status code mapping
+- Standardized error response format
+- Validation error handling
+- Error logging with stack traces
+- Echo middleware for error handling
+- Helper functions for common HTTP errors
+
+## Error Response Format
+
+All API responses follow a consistent format:
+
+### Success Response
+
+```json
+{
+  "success": true,
+  "data": {
+    // Response data
+  }
+}
+```
+
+### Error Response
+
+```json
+{
+  "success": false,
+  "error": {
+    "code": "ERROR_CODE",
+    "message": "Human-readable error message",
+    "details": {
+      // Optional error details
+    }
+  }
+}
+```
+
+## Usage Examples
+
+### Creating and Returning Errors
+
+```go
+// Basic error
+return errors.New(errors.ErrNotFound, err)
+
+// Error with custom message
+return errors.NewWithMessage(errors.ErrNotFound, "User not found", err)
+
+// Error with details
+details := map[string]interface{}{
+    "userId": "123",
+    "reason": "Account deleted",
+}
+return errors.NewWithDetails(errors.ErrNotFound, "User not found", details, err)
+
+// Using helper functions
+return errors.NotFound("User not found", err)
+return errors.BadRequest("Invalid input", err)
+return errors.Unauthorized("Authentication required", err)
+```
+
+### Validation Errors
+
+```go
+// Creating validation errors manually
+fieldErrors := map[string]string{
+    "username": "Username is required",
+    "email":    "Email must be valid",
+}
+return errors.NewValidationError("Validation failed", fieldErrors, err)
+
+// Using the validator
+type CreateUserRequest struct {
+    Username string `json:"username" validate:"required"`
+    Email    string `json:"email" validate:"required,email"`
+    Age      int    `json:"age" validate:"min=18"`
+}
+
+func CreateUserHandler(c echo.Context) error {
+    var req CreateUserRequest
+    if err := errors.BindAndValidate(c, &req); err != nil {
+        return err // Automatically returns validation error response
+    }
+    
+    // Process the request...
+    return errors.SendCreated(c, user)
+}
+```
+
+### Success Responses
+
+```go
+// 200 OK with data
+return errors.SendOK(c, data)
+
+// 201 Created with data
+return errors.SendCreated(c, data)
+
+// 204 No Content
+return errors.SendNoContent(c)
+```
+
+### Domain-Specific Errors
+
+```go
+// Domain error
+return errors.NewDomainError(errors.ErrTenantNotFound, "Tenant not found", err)
+
+// Application error
+return errors.NewApplicationError(errors.ErrInvalidCredentials, "Invalid email or password", err)
+
+// Infrastructure error
+return errors.NewInfrastructureError(errors.ErrUnavailable, "Database connection failed", err)
+```
+
+### Logging
+
+```go
+logger := errors.NewLogger(errors.DefaultLogConfig)
+
+// Log messages
+logger.Debug("Debug message")
+logger.Info("Info message")
+logger.Warn("Warning message")
+logger.Error("Error message")
+
+// Log error with stack trace
+logger.ErrorWithStack(err)
+```
+
+## Error Codes
+
+The system defines the following error codes:
+
+### General Errors
+- `INTERNAL_ERROR`: Internal server error (500)
+- `NOT_FOUND`: Resource not found (404)
+- `BAD_REQUEST`: Invalid request (400)
+- `UNAUTHORIZED`: Authentication required (401)
+- `FORBIDDEN`: Access denied (403)
+- `CONFLICT`: Resource conflict (409)
+- `VALIDATION_ERROR`: Validation error (400)
+- `TIMEOUT`: Request timeout (408)
+- `SERVICE_UNAVAILABLE`: Service unavailable (503)
+- `NOT_IMPLEMENTED`: Not implemented (501)
+- `TOO_MANY_REQUESTS`: Too many requests (429)
+
+### Domain-Specific Errors
+- `TENANT_NOT_FOUND`: Tenant not found (404)
+- `USER_NOT_FOUND`: User not found (404)
+- `KNOWLEDGE_NOT_FOUND`: Knowledge not found (404)
+- `TAG_NOT_FOUND`: Tag not found (404)
+- `COMMENT_NOT_FOUND`: Comment not found (404)
+- `INVALID_CREDENTIALS`: Invalid credentials (401)
+- `EMAIL_ALREADY_EXISTS`: Email already exists (409)
+- `DOMAIN_ALREADY_EXISTS`: Domain already exists (409)
+- `INVALID_ROLE`: Invalid role (400)

--- a/backend/internal/infrastructure/errors/codes.go
+++ b/backend/internal/infrastructure/errors/codes.go
@@ -1,0 +1,105 @@
+package errors
+
+// ErrorCode represents a unique error code for each type of error
+type ErrorCode string
+
+// Error codes
+const (
+	// General errors
+	ErrInternal        ErrorCode = "INTERNAL_ERROR"
+	ErrNotFound        ErrorCode = "NOT_FOUND"
+	ErrBadRequest      ErrorCode = "BAD_REQUEST"
+	ErrUnauthorized    ErrorCode = "UNAUTHORIZED"
+	ErrForbidden       ErrorCode = "FORBIDDEN"
+	ErrConflict        ErrorCode = "CONFLICT"
+	ErrValidation      ErrorCode = "VALIDATION_ERROR"
+	ErrTimeout         ErrorCode = "TIMEOUT"
+	ErrUnavailable     ErrorCode = "SERVICE_UNAVAILABLE"
+	ErrNotImplemented  ErrorCode = "NOT_IMPLEMENTED"
+	ErrTooManyRequests ErrorCode = "TOO_MANY_REQUESTS"
+
+	// Domain specific errors
+	ErrTenantNotFound     ErrorCode = "TENANT_NOT_FOUND"
+	ErrUserNotFound       ErrorCode = "USER_NOT_FOUND"
+	ErrKnowledgeNotFound  ErrorCode = "KNOWLEDGE_NOT_FOUND"
+	ErrTagNotFound        ErrorCode = "TAG_NOT_FOUND"
+	ErrCommentNotFound    ErrorCode = "COMMENT_NOT_FOUND"
+	ErrInvalidCredentials ErrorCode = "INVALID_CREDENTIALS"
+	ErrEmailAlreadyExists ErrorCode = "EMAIL_ALREADY_EXISTS"
+	ErrDomainAlreadyExists ErrorCode = "DOMAIN_ALREADY_EXISTS"
+	ErrInvalidRole        ErrorCode = "INVALID_ROLE"
+)
+
+// HTTPStatusCode maps error codes to HTTP status codes
+func (e ErrorCode) HTTPStatusCode() int {
+	switch e {
+	case ErrNotFound, ErrTenantNotFound, ErrUserNotFound, ErrKnowledgeNotFound, ErrTagNotFound, ErrCommentNotFound:
+		return 404 // Not Found
+	case ErrBadRequest, ErrValidation:
+		return 400 // Bad Request
+	case ErrUnauthorized, ErrInvalidCredentials:
+		return 401 // Unauthorized
+	case ErrForbidden:
+		return 403 // Forbidden
+	case ErrConflict, ErrEmailAlreadyExists, ErrDomainAlreadyExists:
+		return 409 // Conflict
+	case ErrTimeout:
+		return 408 // Request Timeout
+	case ErrUnavailable:
+		return 503 // Service Unavailable
+	case ErrNotImplemented:
+		return 501 // Not Implemented
+	case ErrTooManyRequests:
+		return 429 // Too Many Requests
+	default:
+		return 500 // Internal Server Error
+	}
+}
+
+// DefaultMessage returns a default message for each error code
+func (e ErrorCode) DefaultMessage() string {
+	switch e {
+	case ErrInternal:
+		return "An internal error occurred"
+	case ErrNotFound:
+		return "Resource not found"
+	case ErrBadRequest:
+		return "Invalid request"
+	case ErrUnauthorized:
+		return "Authentication required"
+	case ErrForbidden:
+		return "Access denied"
+	case ErrConflict:
+		return "Resource conflict"
+	case ErrValidation:
+		return "Validation error"
+	case ErrTimeout:
+		return "Request timeout"
+	case ErrUnavailable:
+		return "Service unavailable"
+	case ErrNotImplemented:
+		return "Not implemented"
+	case ErrTooManyRequests:
+		return "Too many requests"
+	case ErrTenantNotFound:
+		return "Tenant not found"
+	case ErrUserNotFound:
+		return "User not found"
+	case ErrKnowledgeNotFound:
+		return "Knowledge not found"
+	case ErrTagNotFound:
+		return "Tag not found"
+	case ErrCommentNotFound:
+		return "Comment not found"
+	case ErrInvalidCredentials:
+		return "Invalid email or password"
+	case ErrEmailAlreadyExists:
+		return "Email already exists"
+	case ErrDomainAlreadyExists:
+		return "Domain already exists"
+	case ErrInvalidRole:
+		return "Invalid role"
+	default:
+		return "An error occurred"
+	}
+}

--- a/backend/internal/infrastructure/errors/echo_validator.go
+++ b/backend/internal/infrastructure/errors/echo_validator.go
@@ -1,0 +1,90 @@
+package errors
+
+import (
+	"net/http"
+	"reflect"
+	stdErrors "errors"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+	"github.com/labstack/echo/v4"
+)
+
+// CustomValidator is a custom validator for Echo
+type CustomValidator struct {
+	validator *validator.Validate
+}
+
+// NewCustomValidator creates a new custom validator
+func NewCustomValidator() *CustomValidator {
+	v := validator.New()
+	
+	// Register custom validation tags here if needed
+	
+	// Use JSON tag names for validation errors
+	v.RegisterTagNameFunc(func(fld reflect.StructField) string {
+		name := strings.SplitN(fld.Tag.Get("json"), ",", 2)[0]
+		if name == "-" {
+			return ""
+		}
+		return name
+	})
+	
+	return &CustomValidator{
+		validator: v,
+	}
+}
+
+// Validate validates a struct
+func (cv *CustomValidator) Validate(i interface{}) error {
+	if err := cv.validator.Struct(i); err != nil {
+		// Convert validator errors to our custom validation error
+		return NewValidationErrorFromValidator(err)
+	}
+	return nil
+}
+
+// BindAndValidate binds and validates a request
+func BindAndValidate(c echo.Context, i interface{}) error {
+	// Bind request body to struct
+	if err := c.Bind(i); err != nil {
+		return NewWithMessage(ErrBadRequest, "Invalid request body", err)
+	}
+	
+	// Validate struct
+	if err := c.Validate(i); err != nil {
+		return err // Already converted to our custom validation error
+	}
+	
+	return nil
+}
+
+// RegisterEchoValidator registers the custom validator with Echo
+func RegisterEchoValidator(e *echo.Echo) {
+	e.Validator = NewCustomValidator()
+}
+
+// ValidationErrorHandler is a middleware that handles validation errors
+func ValidationErrorHandler(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		err := next(c)
+		if err == nil {
+			return nil
+		}
+		
+		// Check if it's a validation error
+		var validationErr *ValidationError
+		if stdErrors.As(err, &validationErr) {
+			return RespondWithError(c, validationErr)
+		}
+		
+		// Check if it's an Echo validation error
+		if he, ok := err.(*echo.HTTPError); ok && he.Code == http.StatusBadRequest {
+			// Convert Echo validation error to our custom error
+			return RespondWithError(c, New(ErrBadRequest, err))
+		}
+		
+		// Pass other errors to the next handler
+		return err
+	}
+}

--- a/backend/internal/infrastructure/errors/errors.go
+++ b/backend/internal/infrastructure/errors/errors.go
@@ -1,0 +1,173 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AppError is the base error type for application errors
+type AppError struct {
+	Code    ErrorCode   `json:"code"`
+	Message string      `json:"message"`
+	Details interface{} `json:"details,omitempty"`
+	Err     error       `json:"-"` // Original error (not serialized)
+}
+
+// Error implements the error interface
+func (e *AppError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %v", e.Message, e.Err)
+	}
+	return e.Message
+}
+
+// Unwrap returns the wrapped error
+func (e *AppError) Unwrap() error {
+	return e.Err
+}
+
+// StatusCode returns the HTTP status code for the error
+func (e *AppError) StatusCode() int {
+	return e.Code.HTTPStatusCode()
+}
+
+// New creates a new AppError with the given code and optional wrapped error
+func New(code ErrorCode, err error) *AppError {
+	return &AppError{
+		Code:    code,
+		Message: code.DefaultMessage(),
+		Err:     err,
+	}
+}
+
+// NewWithMessage creates a new AppError with the given code, message and optional wrapped error
+func NewWithMessage(code ErrorCode, message string, err error) *AppError {
+	return &AppError{
+		Code:    code,
+		Message: message,
+		Err:     err,
+	}
+}
+
+// NewWithDetails creates a new AppError with the given code, message, details and optional wrapped error
+func NewWithDetails(code ErrorCode, message string, details interface{}, err error) *AppError {
+	return &AppError{
+		Code:    code,
+		Message: message,
+		Details: details,
+		Err:     err,
+	}
+}
+
+// ValidationError represents a validation error with field-specific details
+type ValidationError struct {
+	*AppError
+	FieldErrors map[string]string `json:"fieldErrors,omitempty"`
+}
+
+// NewValidationError creates a new ValidationError
+func NewValidationError(message string, fieldErrors map[string]string, err error) *ValidationError {
+	if message == "" {
+		message = "Validation failed"
+	}
+	
+	return &ValidationError{
+		AppError: &AppError{
+			Code:    ErrValidation,
+			Message: message,
+			Err:     err,
+		},
+		FieldErrors: fieldErrors,
+	}
+}
+
+// NewValidationErrorFromStrings creates a ValidationError from a slice of error strings
+func NewValidationErrorFromStrings(errors []string, err error) *ValidationError {
+	return &ValidationError{
+		AppError: &AppError{
+			Code:    ErrValidation,
+			Message: "Validation failed",
+			Err:     err,
+		},
+		FieldErrors: parseValidationErrors(errors),
+	}
+}
+
+// parseValidationErrors converts string errors like "field: error message" to a map
+func parseValidationErrors(errors []string) map[string]string {
+	fieldErrors := make(map[string]string)
+	
+	for _, err := range errors {
+		parts := strings.SplitN(err, ":", 2)
+		if len(parts) == 2 {
+			field := strings.TrimSpace(parts[0])
+			message := strings.TrimSpace(parts[1])
+			fieldErrors[field] = message
+		} else {
+			// If the error doesn't follow the field:message format, use it as is
+			fieldErrors["general"] = err
+		}
+	}
+	
+	return fieldErrors
+}
+
+// DomainError represents an error in the domain layer
+type DomainError struct {
+	*AppError
+}
+
+// NewDomainError creates a new DomainError
+func NewDomainError(code ErrorCode, message string, err error) *DomainError {
+	if message == "" {
+		message = code.DefaultMessage()
+	}
+	
+	return &DomainError{
+		AppError: &AppError{
+			Code:    code,
+			Message: message,
+			Err:     err,
+		},
+	}
+}
+
+// ApplicationError represents an error in the application layer
+type ApplicationError struct {
+	*AppError
+}
+
+// NewApplicationError creates a new ApplicationError
+func NewApplicationError(code ErrorCode, message string, err error) *ApplicationError {
+	if message == "" {
+		message = code.DefaultMessage()
+	}
+	
+	return &ApplicationError{
+		AppError: &AppError{
+			Code:    code,
+			Message: message,
+			Err:     err,
+		},
+	}
+}
+
+// InfrastructureError represents an error in the infrastructure layer
+type InfrastructureError struct {
+	*AppError
+}
+
+// NewInfrastructureError creates a new InfrastructureError
+func NewInfrastructureError(code ErrorCode, message string, err error) *InfrastructureError {
+	if message == "" {
+		message = code.DefaultMessage()
+	}
+	
+	return &InfrastructureError{
+		AppError: &AppError{
+			Code:    code,
+			Message: message,
+			Err:     err,
+		},
+	}
+}

--- a/backend/internal/infrastructure/errors/http.go
+++ b/backend/internal/infrastructure/errors/http.go
@@ -1,0 +1,147 @@
+package errors
+
+import (
+	"net/http"
+
+	"github.com/labstack/echo/v4"
+)
+
+// HTTP error helper functions
+
+// BadRequest returns a 400 Bad Request error
+func BadRequest(message string, err error) error {
+	return NewWithMessage(ErrBadRequest, message, err)
+}
+
+// Unauthorized returns a 401 Unauthorized error
+func Unauthorized(message string, err error) error {
+	if message == "" {
+		message = "Authentication required"
+	}
+	return NewWithMessage(ErrUnauthorized, message, err)
+}
+
+// Forbidden returns a 403 Forbidden error
+func Forbidden(message string, err error) error {
+	if message == "" {
+		message = "Access denied"
+	}
+	return NewWithMessage(ErrForbidden, message, err)
+}
+
+// NotFound returns a 404 Not Found error
+func NotFound(message string, err error) error {
+	if message == "" {
+		message = "Resource not found"
+	}
+	return NewWithMessage(ErrNotFound, message, err)
+}
+
+// Conflict returns a 409 Conflict error
+func Conflict(message string, err error) error {
+	if message == "" {
+		message = "Resource conflict"
+	}
+	return NewWithMessage(ErrConflict, message, err)
+}
+
+// InternalServerError returns a 500 Internal Server Error
+func InternalServerError(message string, err error) error {
+	if message == "" {
+		message = "Internal server error"
+	}
+	return NewWithMessage(ErrInternal, message, err)
+}
+
+// NotImplemented returns a 501 Not Implemented error
+func NotImplemented(message string, err error) error {
+	if message == "" {
+		message = "Not implemented"
+	}
+	return NewWithMessage(ErrNotImplemented, message, err)
+}
+
+// ServiceUnavailable returns a 503 Service Unavailable error
+func ServiceUnavailable(message string, err error) error {
+	if message == "" {
+		message = "Service unavailable"
+	}
+	return NewWithMessage(ErrUnavailable, message, err)
+}
+
+// TooManyRequests returns a 429 Too Many Requests error
+func TooManyRequests(message string, err error) error {
+	if message == "" {
+		message = "Too many requests"
+	}
+	return NewWithMessage(ErrTooManyRequests, message, err)
+}
+
+// Domain-specific error helpers
+
+// TenantNotFound returns a tenant not found error
+func TenantNotFound(err error) error {
+	return NewWithMessage(ErrTenantNotFound, "Tenant not found", err)
+}
+
+// UserNotFound returns a user not found error
+func UserNotFound(err error) error {
+	return NewWithMessage(ErrUserNotFound, "User not found", err)
+}
+
+// KnowledgeNotFound returns a knowledge not found error
+func KnowledgeNotFound(err error) error {
+	return NewWithMessage(ErrKnowledgeNotFound, "Knowledge not found", err)
+}
+
+// TagNotFound returns a tag not found error
+func TagNotFound(err error) error {
+	return NewWithMessage(ErrTagNotFound, "Tag not found", err)
+}
+
+// CommentNotFound returns a comment not found error
+func CommentNotFound(err error) error {
+	return NewWithMessage(ErrCommentNotFound, "Comment not found", err)
+}
+
+// InvalidCredentials returns an invalid credentials error
+func InvalidCredentials(err error) error {
+	return NewWithMessage(ErrInvalidCredentials, "Invalid email or password", err)
+}
+
+// EmailAlreadyExists returns an email already exists error
+func EmailAlreadyExists(err error) error {
+	return NewWithMessage(ErrEmailAlreadyExists, "Email already exists", err)
+}
+
+// DomainAlreadyExists returns a domain already exists error
+func DomainAlreadyExists(err error) error {
+	return NewWithMessage(ErrDomainAlreadyExists, "Domain already exists", err)
+}
+
+// InvalidRole returns an invalid role error
+func InvalidRole(err error) error {
+	return NewWithMessage(ErrInvalidRole, "Invalid role", err)
+}
+
+// HTTP response helpers
+
+// SendOK sends a 200 OK response
+func SendOK(c echo.Context, data interface{}) error {
+	return RespondWithSuccess(c, http.StatusOK, data)
+}
+
+// SendCreated sends a 201 Created response
+func SendCreated(c echo.Context, data interface{}) error {
+	return RespondWithSuccess(c, http.StatusCreated, data)
+}
+
+// SendNoContent sends a 204 No Content response
+func SendNoContent(c echo.Context) error {
+	return RespondWithEmpty(c, http.StatusNoContent)
+}
+
+// SendAccepted sends a 202 Accepted response
+func SendAccepted(c echo.Context, data interface{}) error {
+	return RespondWithSuccess(c, http.StatusAccepted, data)
+}

--- a/backend/internal/infrastructure/errors/logging.go
+++ b/backend/internal/infrastructure/errors/logging.go
@@ -1,0 +1,181 @@
+package errors
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/gommon/log"
+)
+
+// LogLevel defines the level of logging
+type LogLevel int
+
+const (
+	// LogLevelDebug logs everything
+	LogLevelDebug LogLevel = iota
+	// LogLevelInfo logs info, warnings and errors
+	LogLevelInfo
+	// LogLevelWarn logs warnings and errors
+	LogLevelWarn
+	// LogLevelError logs only errors
+	LogLevelError
+)
+
+// LogConfig contains configuration for the logger
+type LogConfig struct {
+	// Level sets the logging level
+	Level LogLevel
+	// IncludeTimestamp includes timestamp in logs
+	IncludeTimestamp bool
+	// IncludeStackTrace includes stack trace for errors
+	IncludeStackTrace bool
+	// StackTraceSize sets the size of the stack trace (number of frames)
+	StackTraceSize int
+}
+
+// DefaultLogConfig is the default logger configuration
+var DefaultLogConfig = LogConfig{
+	Level:            LogLevelInfo,
+	IncludeTimestamp: true,
+	IncludeStackTrace: true,
+	StackTraceSize:   10,
+}
+
+// Logger is a custom logger for the application
+type Logger struct {
+	config LogConfig
+	echo   *echo.Echo
+}
+
+// NewLogger creates a new logger with the given configuration
+func NewLogger(config LogConfig) *Logger {
+	return &Logger{
+		config: config,
+	}
+}
+
+// SetEcho sets the Echo instance for the logger
+func (l *Logger) SetEcho(e *echo.Echo) {
+	l.echo = e
+}
+
+// Debug logs a debug message
+func (l *Logger) Debug(format string, args ...interface{}) {
+	if l.config.Level <= LogLevelDebug {
+		l.log(log.DEBUG, format, args...)
+	}
+}
+
+// Info logs an info message
+func (l *Logger) Info(format string, args ...interface{}) {
+	if l.config.Level <= LogLevelInfo {
+		l.log(log.INFO, format, args...)
+	}
+}
+
+// Warn logs a warning message
+func (l *Logger) Warn(format string, args ...interface{}) {
+	if l.config.Level <= LogLevelWarn {
+		l.log(log.WARN, format, args...)
+	}
+}
+
+// Error logs an error message
+func (l *Logger) Error(format string, args ...interface{}) {
+	if l.config.Level <= LogLevelError {
+		l.log(log.ERROR, format, args...)
+	}
+}
+
+// ErrorWithStack logs an error message with stack trace
+func (l *Logger) ErrorWithStack(err error) {
+	if l.config.Level <= LogLevelError {
+		msg := err.Error()
+		if l.config.IncludeStackTrace {
+			msg = fmt.Sprintf("%s\n%s", msg, l.getStackTrace())
+		}
+		l.log(log.ERROR, msg)
+	}
+}
+
+// log logs a message with the given level
+func (l *Logger) log(level log.Lvl, format string, args ...interface{}) {
+	msg := fmt.Sprintf(format, args...)
+	
+	if l.config.IncludeTimestamp {
+		msg = fmt.Sprintf("[%s] %s", time.Now().Format(time.RFC3339), msg)
+	}
+	
+	if l.echo != nil {
+		// Echo logger doesn't have a Lvl method, so we just use the appropriate log level method
+		switch level {
+		case log.DEBUG:
+			l.echo.Logger.Debug(msg)
+		case log.INFO:
+			l.echo.Logger.Info(msg)
+		case log.WARN:
+			l.echo.Logger.Warn(msg)
+		case log.ERROR:
+			l.echo.Logger.Error(msg)
+		}
+	} else {
+		// Fallback to standard logging if Echo is not set
+		fmt.Println(msg)
+	}
+}
+
+// getStackTrace returns a formatted stack trace
+func (l *Logger) getStackTrace() string {
+	stackSize := l.config.StackTraceSize
+	if stackSize <= 0 {
+		stackSize = 10 // Default stack size
+	}
+	
+	stack := make([]uintptr, stackSize)
+	length := runtime.Callers(3, stack)
+	stack = stack[:length]
+	
+	frames := runtime.CallersFrames(stack)
+	var trace strings.Builder
+	trace.WriteString("Stack trace:\n")
+	
+	for {
+		frame, more := frames.Next()
+		// Skip runtime and standard library frames
+		if !strings.Contains(frame.File, "runtime/") {
+			trace.WriteString(fmt.Sprintf("  %s:%d %s\n", frame.File, frame.Line, frame.Function))
+		}
+		if !more {
+			break
+		}
+	}
+	
+	return trace.String()
+}
+
+// LogErrorWithContext logs an error with request context information
+func LogErrorWithContext(c echo.Context, err error, statusCode int) {
+	req := c.Request()
+	logger := c.Logger()
+	
+	// Format the log message with request details
+	logMsg := fmt.Sprintf("[%s] %s %s - Error: %v (Status: %d)",
+		req.Method,
+		req.Host,
+		req.URL.Path,
+		err,
+		statusCode,
+	)
+	
+	// Log with appropriate level based on status code
+	if statusCode >= 500 {
+		logger.Error(logMsg)
+	} else if statusCode >= 400 {
+		logger.Warn(logMsg)
+	} else {
+		logger.Info(logMsg)
+	}
+}

--- a/backend/internal/infrastructure/errors/middleware.go
+++ b/backend/internal/infrastructure/errors/middleware.go
@@ -1,0 +1,149 @@
+package errors
+
+import (
+	"fmt"
+	"net/http"
+	"runtime/debug"
+	stdErrors "errors"
+
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
+)
+
+// ErrorHandlerConfig contains configuration for the error handler middleware
+type ErrorHandlerConfig struct {
+	// Skipper defines a function to skip middleware
+	Skipper middleware.Skipper
+
+	// LogLevel sets the logging level for errors
+	LogLevel uint
+}
+
+// DefaultErrorHandlerConfig is the default error handler middleware config
+var DefaultErrorHandlerConfig = ErrorHandlerConfig{
+	Skipper: middleware.DefaultSkipper,
+}
+
+// ErrorHandler returns a middleware that handles panics and errors from handlers
+func ErrorHandler() echo.MiddlewareFunc {
+	return ErrorHandlerWithConfig(DefaultErrorHandlerConfig)
+}
+
+// ErrorHandlerWithConfig returns a middleware with config that handles panics and errors from handlers
+func ErrorHandlerWithConfig(config ErrorHandlerConfig) echo.MiddlewareFunc {
+	// Use default config if provided config is empty
+	if config.Skipper == nil {
+		config.Skipper = DefaultErrorHandlerConfig.Skipper
+	}
+
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			// Skip if needed
+			if config.Skipper(c) {
+				return next(c)
+			}
+
+			// Execute the next handler
+			err := next(c)
+			if err != nil {
+				// Handle the error
+				c.Echo().Logger.Error(err)
+				return RespondWithError(c, err)
+			}
+
+			return nil
+		}
+	}
+}
+
+// RecoverWithConfig returns a middleware with config that recovers from panics
+func RecoverWithConfig() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			defer func() {
+				if r := recover(); r != nil {
+					err, ok := r.(error)
+					if !ok {
+						err = fmt.Errorf("%v", r)
+					}
+
+					// Log the stack trace
+					stack := debug.Stack()
+					c.Logger().Error(fmt.Sprintf("[PANIC RECOVER] %v\n%s", err, stack))
+
+					// Create an internal server error
+					appErr := New(ErrInternal, err)
+
+					// Respond with error
+					_ = RespondWithError(c, appErr)
+				}
+			}()
+			return next(c)
+		}
+	}
+}
+
+// ValidationMiddleware returns a middleware that validates request bodies
+func ValidationMiddleware() echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			// The actual validation will be done in the handlers
+			// This middleware is a placeholder for future validation logic
+			return next(c)
+		}
+	}
+}
+
+// NotFoundHandler handles 404 errors
+func NotFoundHandler(c echo.Context) error {
+	return RespondWithError(c, New(ErrNotFound, nil))
+}
+
+// MethodNotAllowedHandler handles 405 errors
+func MethodNotAllowedHandler(c echo.Context) error {
+	return RespondWithError(c, NewWithMessage(ErrBadRequest, "Method not allowed", nil))
+}
+
+// RegisterErrorHandlers registers custom error handlers with Echo
+func RegisterErrorHandlers(e *echo.Echo) {
+	e.HTTPErrorHandler = func(err error, c echo.Context) {
+		// Handle Echo's built-in errors
+		var appErr *AppError
+		if !stdErrors.As(err, &appErr) {
+			he, ok := err.(*echo.HTTPError)
+			if ok {
+				// Convert Echo HTTP errors to our AppError format
+				switch he.Code {
+				case http.StatusNotFound:
+					err = New(ErrNotFound, err)
+				case http.StatusMethodNotAllowed:
+					err = NewWithMessage(ErrBadRequest, "Method not allowed", err)
+				case http.StatusBadRequest:
+					err = New(ErrBadRequest, err)
+				case http.StatusUnauthorized:
+					err = New(ErrUnauthorized, err)
+				case http.StatusForbidden:
+					err = New(ErrForbidden, err)
+				default:
+					// Use the message from the HTTP error if available
+					if he.Message != nil {
+						if msg, ok := he.Message.(string); ok {
+							err = NewWithMessage(ErrInternal, msg, err)
+						} else {
+							err = New(ErrInternal, err)
+						}
+					} else {
+						err = New(ErrInternal, err)
+					}
+				}
+			}
+		}
+
+		// Use our standard error response
+		if err := RespondWithError(c, err); err != nil {
+			// If responding with error fails, log it and send a basic response
+			c.Logger().Error(err)
+			_ = c.NoContent(http.StatusInternalServerError)
+		}
+	}
+}

--- a/backend/internal/infrastructure/errors/response.go
+++ b/backend/internal/infrastructure/errors/response.go
@@ -1,0 +1,113 @@
+package errors
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"runtime/debug"
+
+	"github.com/labstack/echo/v4"
+)
+
+// ErrorResponse is the standardized error response format
+type ErrorResponse struct {
+	Success bool        `json:"success"`
+	Error   *ErrorData  `json:"error"`
+}
+
+// ErrorData contains detailed error information
+type ErrorData struct {
+	Code    string      `json:"code"`
+	Message string      `json:"message"`
+	Details interface{} `json:"details,omitempty"`
+}
+
+// RespondWithError sends a standardized error response
+func RespondWithError(c echo.Context, err error) error {
+	// Default to internal server error
+	statusCode := http.StatusInternalServerError
+	errorCode := ErrInternal
+	message := "An internal server error occurred"
+	var details interface{}
+
+	// Try to get more specific error information
+		var validationErr *ValidationError
+		if errors.As(err, &validationErr) {
+			statusCode = validationErr.StatusCode()
+			errorCode = validationErr.Code
+			message = validationErr.Message
+			details = validationErr.FieldErrors
+		} else {
+			var appErr *AppError
+			if errors.As(err, &appErr) {
+				statusCode = appErr.StatusCode()
+				errorCode = appErr.Code
+				message = appErr.Message
+				details = appErr.Details
+			}
+		}
+
+	// Log the error
+	logError(c, err, statusCode)
+
+	// Create the response
+	response := ErrorResponse{
+		Success: false,
+		Error: &ErrorData{
+			Code:    string(errorCode),
+			Message: message,
+			Details: details,
+		},
+	}
+
+	return c.JSON(statusCode, response)
+}
+
+// logError logs the error with appropriate level based on status code
+func logError(c echo.Context, err error, statusCode int) {
+	// Get request information
+	req := c.Request()
+	path := req.URL.Path
+	method := req.Method
+
+	// Format the log message
+	logMsg := fmt.Sprintf("[%s] %s - Error: %v", method, path, err)
+
+	// Log with appropriate level based on status code
+	logger := c.Logger()
+
+	if statusCode >= 500 {
+		// For server errors, log at error level with stack trace
+		logger.Error(logMsg)
+		logger.Error(string(debug.Stack()))
+	} else if statusCode >= 400 {
+		// For client errors, log at warn level
+		logger.Warn(logMsg)
+	} else {
+		// For other status codes, log at info level
+		logger.Info(logMsg)
+	}
+}
+
+// SuccessResponse is the standardized success response format
+type SuccessResponse struct {
+	Success bool        `json:"success"`
+	Data    interface{} `json:"data,omitempty"`
+}
+
+// RespondWithSuccess sends a standardized success response
+func RespondWithSuccess(c echo.Context, statusCode int, data interface{}) error {
+	response := SuccessResponse{
+		Success: true,
+		Data:    data,
+	}
+
+	return c.JSON(statusCode, response)
+}
+
+// RespondWithEmpty sends a success response with no data
+func RespondWithEmpty(c echo.Context, statusCode int) error {
+	return c.JSON(statusCode, SuccessResponse{
+		Success: true,
+	})
+}

--- a/backend/internal/infrastructure/errors/validation.go
+++ b/backend/internal/infrastructure/errors/validation.go
@@ -1,0 +1,64 @@
+package errors
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// ValidationErrorsToMap converts validator.ValidationErrors to a map of field:message
+func ValidationErrorsToMap(err error) map[string]string {
+	fieldErrors := make(map[string]string)
+	
+	if err == nil {
+		return fieldErrors
+	}
+	
+	validationErrors, ok := err.(validator.ValidationErrors)
+	if !ok {
+		// If it's not a validator.ValidationErrors, just return a generic error
+		fieldErrors["general"] = err.Error()
+		return fieldErrors
+	}
+	
+	for _, e := range validationErrors {
+		// Convert the field name to JSON format (usually lowercase first letter)
+		field := e.Field()
+		if len(field) > 0 {
+			field = strings.ToLower(field[:1]) + field[1:]
+		}
+		
+		// Create a user-friendly error message based on the validation tag
+		var message string
+		switch e.Tag() {
+		case "required":
+			message = fmt.Sprintf("%s is required", field)
+		case "email":
+			message = fmt.Sprintf("%s must be a valid email address", field)
+		case "min":
+			message = fmt.Sprintf("%s must be at least %s characters long", field, e.Param())
+		case "max":
+			message = fmt.Sprintf("%s must be at most %s characters long", field, e.Param())
+		case "oneof":
+			message = fmt.Sprintf("%s must be one of: %s", field, e.Param())
+		case "uuid":
+			message = fmt.Sprintf("%s must be a valid UUID", field)
+		case "url":
+			message = fmt.Sprintf("%s must be a valid URL", field)
+		default:
+			// For other validation tags, use a generic message
+			message = fmt.Sprintf("%s failed validation: %s", field, e.Tag())
+		}
+		
+		fieldErrors[field] = message
+	}
+	
+	return fieldErrors
+}
+
+// NewValidationErrorFromValidator creates a ValidationError from validator.ValidationErrors
+func NewValidationErrorFromValidator(err error) *ValidationError {
+	fieldErrors := ValidationErrorsToMap(err)
+	return NewValidationError("Validation failed", fieldErrors, err)
+}


### PR DESCRIPTION
## 概要
Issue #4 の対応として、バックエンドのエラーハンドリングシステムを実装しました。

## 実装内容

1. **カスタムエラー型の定義**:
   - 基本となる `AppError` 型を作成
   - 各レイヤー（ドメイン、アプリケーション、インフラストラクチャ）に特化したエラー型を実装
   - フィールド単位の詳細情報を持つバリデーションエラーを追加

2. **エラーコードの定義**:
   - 標準的なエラーコードを定義
   - エラーコードを適切なHTTPステータスコードにマッピング
   - アプリケーション固有のエラーコードを追加

3. **エラーメッセージの標準化**:
   - 各エラーコードのデフォルトメッセージを実装
   - 一般的なエラーシナリオ用のヘルパー関数を作成

4. **バリデーションエラーの実装**:
   - go-playground/validator との統合
   - フィールド単位のエラーを持つカスタムバリデーションエラーフォーマットを作成
   - リクエストのバインドとバリデーション用のヘルパーを追加

5. **ミドルウェアでのエラーハンドリング**:
   - カスタムエラーハンドリングミドルウェアを実装
   - パニックリカバリーミドルウェアを追加
   - バリデーションミドルウェアを作成

6. **ロギング機能の実装**:
   - 設定可能なレベルを持つカスタムロガーを実装
   - スタックトレースのサポートを追加
   - コンテキスト対応のエラーロギングを作成

## テスト
以下のエラータイプでテストを行いました：

1. **バリデーションエラー** (400 Bad Request)
2. **Not Found エラー** (404 Not Found)
3. **認証エラー** (401 Unauthorized)

## ドキュメント
`backend/internal/infrastructure/errors/README.md` に詳細な使用例とドキュメントを追加しました。

この実装により、Issue #4 の要件をすべて満たしています。